### PR TITLE
Added: Remove Empty Strings flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,28 @@ Will produce:
   }
 ]
 ```
+
+You can remove empty strings from objects and arrays with the `--remove-empty-strings` flag.
+
+**Note:** this happens for both objects and arrays, which may have undesirable affects.
+
+```csv
+name.first,name.last,age,pets.1,pets.2
+daniel,,34,,
+```
+
+```shell
+$ csv2json --in test.csv -d . -n --remove-empty-strings
+```
+
+```json
+[
+  {
+    "age": "34",
+    "name": {
+      "first": "daniel"
+    },
+    "pets": []
+  }
+]
+```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ use clap::{App, Arg, ArgMatches};
 
 pub const DIMENSIONAL_SEPARATOR: &str = "dimensional-separator";
 pub const NUMERIC_ARRAYS: &str = "numeric-arrays";
+pub const REMOVE_EMPTY_STRINGS: &str = "remove-empty-strings";
 
 pub fn get_matches<'a>() -> ArgMatches<'a> {
     configure_app().get_matches()
@@ -33,6 +34,13 @@ fn configure_app<'a, 'b>() -> App<'a, 'b> {
                 .long(NUMERIC_ARRAYS)
                 .value_name(NUMERIC_ARRAYS)
                 .help("Indicates the csv contains arrays represented by numeric keys. Use with -d")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name(REMOVE_EMPTY_STRINGS)
+                .long(REMOVE_EMPTY_STRINGS)
+                .value_name(REMOVE_EMPTY_STRINGS)
+                .help("Removes keys that contain empty strings")
                 .takes_value(false),
         )
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -53,6 +53,32 @@ pub fn prepare_upsert(entry: Entry, data: Value) -> Value {
     }
 }
 
+pub fn remove_empty_strings(value: &mut Value) {
+    match value {
+        Value::Object(object) => remove_empty_strings_from_object(object),
+        Value::Array(arr) => remove_empty_strings_from_array(arr),
+        _ => {},
+    }
+}
+
+fn remove_empty_strings_from_object(object: &mut Map<String, Value>) {
+    let mut keys_to_remove : Vec<String> = vec![];
+    object
+        .iter_mut()
+        .for_each(|(key, mut value)| {
+            if value.is_string() && value.as_str().unwrap().is_empty() {
+                keys_to_remove.push(key.to_owned());
+            } else {
+                remove_empty_strings(&mut value)
+            }
+        });
+    keys_to_remove.iter().for_each(|key| { object.remove(key); })
+}
+
+fn remove_empty_strings_from_array(arr: &mut Vec<Value>) {
+    arr.retain(|value| !(value.is_string() && value.as_str().unwrap().is_empty()));
+}
+
 fn merge_values(v1: Value, v2: Value) -> Value {
     // If both values are objects combine on keys
     if v1.is_object() && v2.is_object() {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -57,22 +57,22 @@ pub fn remove_empty_strings(value: &mut Value) {
     match value {
         Value::Object(object) => remove_empty_strings_from_object(object),
         Value::Array(arr) => remove_empty_strings_from_array(arr),
-        _ => {},
+        _ => {}
     }
 }
 
 fn remove_empty_strings_from_object(object: &mut Map<String, Value>) {
-    let mut keys_to_remove : Vec<String> = vec![];
-    object
-        .iter_mut()
-        .for_each(|(key, mut value)| {
-            if value.is_string() && value.as_str().unwrap().is_empty() {
-                keys_to_remove.push(key.to_owned());
-            } else {
-                remove_empty_strings(&mut value)
-            }
-        });
-    keys_to_remove.iter().for_each(|key| { object.remove(key); })
+    let mut keys_to_remove: Vec<String> = vec![];
+    object.iter_mut().for_each(|(key, mut value)| {
+        if value.is_string() && value.as_str().unwrap().is_empty() {
+            keys_to_remove.push(key.to_owned());
+        } else {
+            remove_empty_strings(&mut value)
+        }
+    });
+    keys_to_remove.iter().for_each(|key| {
+        object.remove(key);
+    })
 }
 
 fn remove_empty_strings_from_array(arr: &mut Vec<Value>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn main() {
         .expect("You must specify an input csv with --in");
     let ds = cli_matches.value_of(cli::DIMENSIONAL_SEPARATOR);
     let na = cli_matches.is_present(cli::NUMERIC_ARRAYS);
+    let res = cli_matches.is_present(cli::REMOVE_EMPTY_STRINGS);
     let file = File::open(csv_file).expect("Could not read csv file");
     let mut csv_reader = csv::Reader::from_reader(file);
 
@@ -36,10 +37,14 @@ fn main() {
                 items.insert(key, prepared_value);
             });
 
-            let items = json!(items);
+            let mut items = json!(items);
 
             if na {
-                return data::group_numeric_arrays(items);
+                items = data::group_numeric_arrays(items);
+            }
+
+            if res {
+                data::remove_empty_strings(&mut items);
             }
 
             items


### PR DESCRIPTION
One day it might be better to have this as two flags, `--remove-empty-strings-from-objects` and `--remove-empty-strings-from-arrays` but we don't need it for our use case.