### PR TITLE
Delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,35 @@ Usage:
 $ csv2json --in <csv file> > <json file>
 ```
 
+### CSV Delimiter
+
+By default, the csv is split by commas. If your csv is delimited in a different way, you can
+specify the character using the `--delimiter` or `-d` option
+
+Eg:
+```csv
+colon:delimited
+one:two
+```
+Without specifying:
+```json
+[
+  {
+    "colon:delimited": "one:two"
+  }
+]
+```
+Using `-d :`
+```json
+[
+  {
+    "colon": "one",
+    "delimited": "two"
+  }
+]
+```
+
+
 ### Dimensional Seperator
 
 If your CSV contains multidimensional data, you can add use the dimensional separator argument `-d`

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Setting the separator `-d .`:
 
 ### Arrays
 
-You can use `--arrays` (or `-n`) with `-d` to break items into arrays
+You can use `--arrays` (or `-a`) with `-d` to break items into arrays
 
 ```csv
 name,pets.1,pets.2
@@ -75,7 +75,7 @@ Without using arrays:
 ]
 ```
 
-With arrays (`-d . -n`):
+With arrays (`-d . -a`):
 ```json
 [
   {
@@ -121,7 +121,7 @@ daniel,,34,,
 ```
 
 ```shell
-$ csv2json --in test.csv -d . -n --remove-empty-strings
+$ csv2json --in test.csv -d . -a --remove-empty-strings
 ```
 
 ```json
@@ -149,7 +149,7 @@ daniel,mason,yuki,cat,tinky,cat
 ```
 
 ```shell
-$ csv2json --in test.csv -d . -n --remove-empty-strings --remove-empty-objects
+$ csv2json --in test.csv -d . -a --remove-empty-strings --remove-empty-objects
 ```
 
 ```json
@@ -200,7 +200,7 @@ daniel,mason,yuki,cat,tinky,cat
 
 Running csv2json with the following naming template
 ```shell
-$ csv2json --in test.csv --out-dir . --out-name "{name.first}-{name.last}" -d . -n --remove-empty-strings --remove-empty-objects
+$ csv2json --in test.csv --out-dir . --out-name "{name.first}-{name.last}" -d . -a --remove-empty-strings --remove-empty-objects
 ```
 
 Will produce the following files

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 use clap::{app_from_crate, crate_authors, crate_description, crate_name, crate_version};
 use clap::{App, Arg, ArgMatches};
 
+pub const DELIMITER: &str = "delimiter";
 pub const DIMENSIONAL_SEPARATOR: &str = "dimensional-separator";
 pub const ARRAYS: &str = "arrays";
 pub const REMOVE_EMPTY_STRINGS: &str = "remove-empty-strings";
@@ -41,6 +42,15 @@ fn configure_app<'a, 'b>() -> App<'a, 'b> {
                 .value_name("TEMPLATE")
                 .help("The template to use for naming multiple output files")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::with_name(DELIMITER)
+                .short("d")
+                .long(DELIMITER)
+                .value_name("DELIMITER")
+                .help("What delimiter does your csv use")
+                .takes_value(true)
+                .default_value(","),
         )
         .arg(
             Arg::with_name(DIMENSIONAL_SEPARATOR)

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,8 @@ fn main() {
         .expect("You must specify an input csv with --in");
     let out_dir = cli_matches.value_of(cli::OUT_DIR);
     let out_name = cli_matches.value_of(cli::OUT_NAME);
+    let delimiter = cli_matches.value_of(cli::DELIMITER).unwrap(); // Has a default
+    let delimiter_byte = *delimiter.as_bytes().first().expect("No delimiter provided");
     let ds = cli_matches.value_of(cli::DIMENSIONAL_SEPARATOR);
     let na = cli_matches.is_present(cli::ARRAYS);
     let res = cli_matches.is_present(cli::REMOVE_EMPTY_STRINGS);
@@ -30,7 +32,7 @@ fn main() {
     let file = File::open(csv_file).expect("Could not read csv file");
     let boolean_columns = cli_matches.values_of_lossy(cli::BOOLEAN).unwrap_or_else(|| vec![]);
     let numeric_columns = cli_matches.values_of_lossy(cli::NUMERIC).unwrap_or_else(|| vec![]);
-    let mut csv_reader = csv::Reader::from_reader(file);
+    let mut csv_reader = csv::ReaderBuilder::new().delimiter(delimiter_byte).from_reader(file);
 
     let raw_rows: Vec<HashMap<String, Value>> = csv_reader
         .deserialize()


### PR DESCRIPTION
Specify different delimiters, good suggestion by @norcalli in #12. Unfortunately I couldn't find an easy way to unescape input strings (such as `\t`), but this will work for non escaped delimiters.