### PR TITLE
Fixed: Stringifying Values adds double quotes, keep raw data raw

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -234,9 +234,9 @@ pub fn value_to_number(value: &Value) -> Number {
     }
 }
 
-pub fn row_to_values(row: HashMap<String, String>) -> HashMap<String, Value> {
-    row.into_iter()
-        .map(|(key, value)| (key, Value::String(value)))
+pub fn row_to_values(row: &HashMap<String, String>) -> HashMap<String, Value> {
+    row.iter()
+        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
         .collect()
 }
 


### PR DESCRIPTION
Before:
```
$ csv2json --in data/organisations.csv --out-dir build --out-name "{slug}"
Writing to build/"apolitical".json
Writing to build/"my-awesome-place".json
```
After:
```
$ csv2json --in data/organisations.csv --out-dir build --out-name "{slug}"
Writing to build/apolitical.json
Writing to build/my-awesome-place.json

```